### PR TITLE
added cookbook attribute to service template

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'you@example.com'
 license 'Apache License, Version 2.0'
 description 'Installs/Configures spring-boot-app'
 long_description 'Installs/Configures spring-boot-app'
-version '0.3.1'
+version '0.3.2'
 
 depends 'java'

--- a/providers/web_app.rb
+++ b/providers/web_app.rb
@@ -46,6 +46,7 @@ action :install do
     mode '0755'
     owner 'root'
     group 'root'
+    cookbook 'spring-boot'
     variables(
       description: new_resource.name,
       user: new_resource.user,


### PR DESCRIPTION
Fixes exception when other cookbooks try to use the `spring_boot_web_app` resource  When the cookbook I am using creates a `spring_boot_web_app` resource it fails to find the `bootapp.service.erb`. This appears to be due to the bootapp_service_template defaults its cookbook attribute to the cookbook that is using the resource, rather than the spring-boot cookbook that actually contains the template declaration. Explicitly setting the `cookbook` attribute in the template declaration of the `spring_boot_web_app` resource to `spring-boot` allows external cookbooks to be able to use the `spring_boot_web_app` resource.
